### PR TITLE
Fix: Remove unused ConfidenceVector import

### DIFF
--- a/src/asr_got_reimagined/domain/services/got_processor.py
+++ b/src/asr_got_reimagined/domain/services/got_processor.py
@@ -10,7 +10,6 @@ from loguru import logger
 from src.asr_got_reimagined.domain.models.common_types import (
     ComposedOutput,
     GoTProcessorSessionData,
-    ConfidenceVector, # Keep if used by _prepare_properties_for_neo4j, otherwise remove if helper is removed
 )
 # ASRGoTGraph and related Pydantic models (Node, Edge, etc.) from graph_state are no longer needed here
 # as GoTProcessor will not interact with the graph structure directly.


### PR DESCRIPTION
Removes an unused import of `ConfidenceVector` from `src.asr_got_reimagined.domain.models.common_types` in the file `src/asr_got_reimagined/domain/services/got_processor.py`.

This import was causing an `ImportError` at server startup because the `ConfidenceVector` name is not defined in `common_types.py`, and the component that previously used it (`_prepare_properties_for_neo4j`) had been removed. This change resolves the server startup crash.